### PR TITLE
show average speed per 5 second on the map

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/StatisticElement.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/StatisticElement.java
@@ -41,6 +41,12 @@ public enum StatisticElement {
             return StringUtils.formatSpeedInKmPerHour(context, statistics.getAvgMovingSpeedMeterPerSecond());
         }
     },
+    DISTANCE_M_5_SEC() {
+        @Override
+        public String getText(Context context, TrackStatistics statistics) {
+            return StringUtils.formatSpeedMeterPer5Sec(context, statistics.getAvgMovingSpeedMeterPerSecond());
+        }
+    },
     PACE_MIN_KM() {
         @Override
         public String getText(Context context, TrackStatistics statistics) {

--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/StringUtils.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/StringUtils.java
@@ -71,6 +71,17 @@ public class StringUtils {
         return context.getString(R.string.stat_distance_with_unit, context.getString(R.string.stat_minute_seconds, minutes, seconds), context.getString(R.string.unit_minute_per_mile));
     }
 
+    public static String formatSpeedMeterPer5Sec(Context context, float meterPerSeconds) {
+        if (meterPerSeconds == 0) {
+            return "0 m/5s";
+        }
+
+        // Calculate the distance covered in 5 seconds
+        float distanceCovered = meterPerSeconds * 5;
+
+        return context.getString(R.string.stat_distance_with_unit, formatDecimal(distanceCovered), context.getString(R.string.stats_meter_5_seconds));
+    }
+
     private static String formatDecimal(double value) {
         return StringUtils.formatDecimal(value, 2);
     }

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -50,6 +50,7 @@
         <item>CATEGORY</item>
         <item>MOVING_TIME</item>
         <item>DISTANCE_KM</item>
+        <item>DISTANCE_M_5_SEC</item>
         <item>PACE_MIN_KM</item>
     </string-array>
 

--- a/src/main/res/values/non-translatable-strings.xml
+++ b/src/main/res/values/non-translatable-strings.xml
@@ -27,6 +27,7 @@
     <string name="stat_minute_seconds" translatable="false"><![CDATA[<b>%1$d:%2$02d</b>]]></string>
     <string name="stat_category" translatable="false"><![CDATA[<b>%1$s</b>]]></string>
     <string name="stat_time" translatable="false"><![CDATA[<b>%1$s</b>]]></string>
+    <string name="stats_meter_5_seconds" translatable="false">m/5s</string>
 
     <string name="report_issue_link" translatable="false">https://github.com/OpenTracksApp/OSMDashboard/issues/new?labels=bug&amp;body=%1$s</string>
 


### PR DESCRIPTION
# Issue https://github.com/rilling/OSMDashboard-Winter-2024-SOEN-6431/issues/36

## Work Done

1. Show average speed per 5 seconds on the map

## Code changes

1. Added additional item in default statistic element array in `src\main\res\values\arrays.xml`.
2. Defined string element in `src\main\res\values\non-translatable-strings.xml` to show average speed unit in meter per 5 seconds
3. Added ```formatSpeedMeterPer5Sec``` function in `src\main\java\de\storchp\opentracks\osmplugin\utils\StringUtils.java` file to format the string.
4. Added `getText` method for `DISTANCE_M_5_SEC` in `src\main\java\de\storchp\opentracks\osmplugin\utils\StatisticElement.java` file to get the formatted string to be shown on the map